### PR TITLE
Rootlog devAdd action splitter and regex former

### DIFF
--- a/src/action-parser.ts
+++ b/src/action-parser.ts
@@ -1,11 +1,31 @@
 import { Action, ActionCombat, ActionCraft, ActionDominance, ActionGainVP, ActionMove, ActionReveal, Card, CardName, CorvidSpecial, Faction, Item, ItemState, Piece, SubjectReveal, Suit } from './interfaces';
 import { parseConspiracyAction, parseCultAction, parseDuchyAction, parseEyrieAction, parseMarquiseAction, parseRiverfolkAction, parseVagabondAction, parseWoodlandAction } from './parsers';
+import { formRegex } from './utils/regex-former';
 
 const ALL_FACTIONS = Object.values(Faction).join('');
 const ALL_SUITS = Object.values(Suit).join('');
 const ALL_ITEMS = Object.values(Item).join('');
 const ALL_PIECES = Object.values(Piece).join('');
 const ALL_ITEM_STATE = Object.values(ItemState).join('');
+
+// These regexes have been tested, but not extensively. They do not yet contain the information unique to each faction, other than
+// pieces of the format w_x, b_x, t_x
+// With the move regex especially, be careful of the order you check for actions in: As things are now, it treats `despot->$` as
+// the unrelated letters 'despo' followed by `t->$`
+
+// These also do not work on composite actions! Please first decompose actions like (t1+t2)->5 into simple actions with the actionSplitter
+
+// const COMBAT_REGEX = formRegex('[Faction|||attacker]X<Faction|||defender><Clearing|||battleClearing>[<Suit|||defenderAmbush>@[<Suit|||attackerAmbush>@]][(<Roll|||attackerRoll>,<Roll|||defenderRoll>)]');
+const MOVE_REGEX = formRegex('[Number|||countMoved]<Component|||componentMoved>[Location|||origin]->[Location|||destination]');
+const MOVE_PIECE_REGEX = formRegex('[Number|||countMoved]<Piece|||pieceMoved>[Location|||origin]->[Location|||destination]');
+const MOVE_CARD_REGEX = formRegex('[Number|||countMoved]<Card|||cardMoved>[Location|||origin]->[Location|||destination]');
+// const MOVE_ITEM_REGEX = formRegex('[Number|||countMoved]<Item|||itemMoved>[Location|||origin]->[Location|||destination]');
+const REVEAL_REGEX = formRegex('[Number|||countRevealed][Card||cardRevealed][Faction|||revealingFaction]\\^[Faction|||revealedFaction]');
+const SCORE_VP_REGEX = formRegex('[Faction|||scoringFaction]++[Number|||points]');
+const REDUCE_VP_REGEX = formRegex('[Faction|||scoringFaction]--[Number|||points]');
+const CRAFT_REGEX = formRegex('Z<Craftable|||crafted>');
+const REMOVE_FACTION_MARKER_REGEX = formRegex('++-><FactionBoard|||targetFaction>');
+const CLEAR_MOUNTAIN_PATH_REGEX = formRegex('<Clearing|||lowerClearing>_<Clearing|||upperClearing>->');
 
 const GROUPING_REGEX = new RegExp(`\\((.+)\\)(.+)`);
 const COMBAT_REGEX = new RegExp(`^([${ALL_FACTIONS}])?X([${ALL_FACTIONS}])([0-9]{1,2})`);

--- a/src/utils/action-splitter.ts
+++ b/src/utils/action-splitter.ts
@@ -1,0 +1,42 @@
+const GROUPING_REGEX = new RegExp(`\\((.+)\\)(.+)`);
+
+/**
+ * If the action passed to this function is composite, e.g., (2%c+%h)$V->d, it decomposes it into an array of equivalent actions
+ * If not, it simply returns the same action in an array
+ * This makes parsing the regexes significantly easier, and lets us continue to use named regexes
+ * @param action The action to decompose
+ * @example
+ * // returns ['2%c$V->d', '%h$V->d']
+ * splitAction('(2%c+%h)$V->d')
+ * @example
+ * // returns ['t1->', 't2->', 't5->']
+ * splitAction('t1+t2+t5->')
+ */
+export function splitAction(action: string): string[] {
+  // Don't split actions that contain '++', because these actions can never be composite
+  if (action.includes('++')) {
+    return [action];
+  }
+  // Don't split actions that don't contain '+', because these actions are by definition not composite
+  if (!action.includes('+')) {
+    return [action];
+  }
+
+  // Test if the action involves some text enclosed in parentheses, followed by some text that isn't
+  // If so, this is grouping components
+  if (GROUPING_REGEX.test(action)) {
+    const [_, grouped, outerTerm] = action.match(GROUPING_REGEX);
+    return grouped.split('+').map(g => `${g}${outerTerm}`);
+  } else {
+    // The action contains a '+' but no text enclosed in parentheses
+    // This means this is grouping movement or revealing
+    const match = action.match(/(?<lhs>.*[^<])(?<delim>->|\^)(?<rhs>.*)/);
+    let [lhs, rhs, delim] = (match == null) ? [action, '', ''] : [match.groups.lhs, match.groups.rhs, match.groups.delim];
+  
+    if (lhs.includes('+')) {
+      return lhs.split('+').map(component => `${component}${delim}${rhs}`);
+    } else {
+      return rhs.split('+').map(component => `${lhs}${delim}${component}`);
+    }
+  }
+}

--- a/src/utils/regex-former.ts
+++ b/src/utils/regex-former.ts
@@ -1,0 +1,174 @@
+import { CardName, Faction, Item, ItemState, Piece, Suit } from '../interfaces';
+
+const DIVIDER_BEFORE_GROUP_NAME = '|||';  // arbitrarily chosen to be a divider that will never appear in Rootlog code
+
+const ALL_FACTIONS = `[${Object.values(Faction).join('')}]`;          // [CEAVGLODP]
+const ALL_SUITS = `[${Object.values(Suit).join('')}]`;                // [BFMR]
+const ALL_ITEM_TYPES = `[${Object.values(Item).join('')}]`;           // [sbcxhtrf]
+const ALL_PIECE_TYPES = `[${Object.values(Piece).join('')}]`;         // [wpbtr]
+const ALL_ITEM_STATE = `[${Object.values(ItemState).join('')}]`;      // [re]
+const ALL_CARD_NAMES = `(${Object.values(CardName).join('|')})`;      // (@|dom|armor|bank|...|tun)
+
+const CLEARING = '(1[0-2]|[1-9])';                                    // a number from 1-12
+const FOREST = `(${CLEARING}(_${CLEARING}){2,})`;                     // 3+ adjacent clearings, separated by underscores
+const FACTION_BOARD = `(${ALL_FACTIONS}?\\$)`;                        // $, optionally preceeded by a faction
+const HAND = `(${ALL_FACTIONS})`;                                     // A faction
+
+// In order from most-to-least specific
+const ALL_LOCATIONS = `(${FOREST}|${CLEARING}|${FACTION_BOARD}|${HAND}|${ALL_ITEM_STATE})`;
+
+// [Faction]<PieceType>[_<subtype>],  subtype must be one letter
+const PIECE_REGEX_STRING = `(${ALL_FACTIONS})?(${ALL_PIECE_TYPES})(_[a-z])?`;
+// [Suit]#[CardName]
+const CARD_REGEX_STRING = `(${ALL_SUITS})?#${ALL_CARD_NAMES}?`;
+// %<ItemType> or %_ to represent 'all items'
+const ITEM_REGEX_STRING = `(%${ALL_ITEM_TYPES}|%_)`;
+// a card, piece, or item
+const COMPONENT_REGEX_STRING = `(${CARD_REGEX_STRING}|${PIECE_REGEX_STRING}|${ITEM_REGEX_STRING})`;
+
+// base should be of the format 'code|||name' or else just 'code'
+// ex: 'number|||amountOfPoints',  'piece'
+const parseForRegexString = function(str: string): string {
+  const [groupCode, groupName] = str.split(DIVIDER_BEFORE_GROUP_NAME);
+
+  switch (groupCode.toLowerCase()) {
+    case ('number'):
+      return _parseForRegexString('\\d*', groupName);
+    case ('piece'):
+      return _parseForRegexString(PIECE_REGEX_STRING, groupName);
+    case ('card'):
+      return _parseForRegexString(CARD_REGEX_STRING, groupName);
+    case ('item'):
+      return _parseForRegexString(ITEM_REGEX_STRING, groupName);
+    case ('component'):
+      return _parseForRegexString(COMPONENT_REGEX_STRING, groupName);
+    case ('clearing'):
+      return _parseForRegexString(CLEARING, groupName);
+    case ('factionboard'):
+      return _parseForRegexString(FACTION_BOARD, groupName);
+    case ('location'):
+      return _parseForRegexString(ALL_LOCATIONS, groupName);
+    case ('craftable'):
+      return _parseForRegexString(`(${ALL_CARD_NAMES}|${ITEM_REGEX_STRING})`, groupName);
+    case ('suit'):
+      return _parseForRegexString(ALL_SUITS, groupName);
+    case ('faction'):
+      return _parseForRegexString(ALL_FACTIONS, groupName);
+    case ('roll'):
+      return _parseForRegexString(`[0-3]`, groupName);
+    default:
+      return _parseForRegexString(groupCode, groupName);
+    }
+}
+
+const _parseForRegexString = function(parsedRegex: string, groupName: string): string {
+  // if we have a group name, return `(?<groupName>regex)`, else return `(regex)`
+  return groupName !== undefined ? `(?<${groupName}>${parsedRegex})` : `(${parsedRegex})`;
+}
+
+// given a pseudo-regex, form a valid regex
+// ex: `Z<Craftable>` returns `Z((@|dom|armor|bank|...|tun)|(%[bcthxsrf]|%_))`
+// Note that this function WILL NOT WORK on composite actions, like (t1+t2)->5
+// Please first call the action splitter to turn the composite action into an array of individual actions
+export function formRegex(pseudoRegex: string): RegExp {
+  // Left-hand side: All characters until the divider. It cannot end with < (To avoid treating <-> from trick as a -> divider)
+  // Divider: -> or ^
+  // Right-hand side: All remaining characters in the string
+  const match = pseudoRegex.match(/(?<lhs>.*[^<])(?<delim>->|\^)(?<rhs>.*)/);
+  let [lhs, rhs, delim] = (match == null) ? [pseudoRegex, '', ''] : [match.groups.lhs, match.groups.rhs, match.groups.delim];
+  if (delim === '^') {
+    delim = '\\^';  // We have to escape the special regex character to treat it as a literal
+  }
+
+  let finalParsedRegexString = '';
+
+  [lhs, rhs].forEach((splitString, matchIdx) => {
+    if (splitString == null) {
+      return;  // TODO: Test? This seems wrong...
+    }
+
+    let parsedRegexString = '';
+    let nestedStrings = [];
+    let currentString = '';
+    let openOptionalSections = 0;
+    let openMandatorySections = 0;
+
+    if (matchIdx === 1) {
+      finalParsedRegexString += delim;  // Re-add the removed delimiter after forming the left-hand side
+    }
+
+    [...splitString].forEach((c, idx) => {
+      switch (c) {
+        case '[':
+          if (openOptionalSections === 0 && openMandatorySections === 0) {
+            // We are not nested in brackets, so what was written up to this point was literal text
+            parsedRegexString += currentString;
+          } else {
+            // We *are* nested in brackets
+            // Store the currentString in nested strings to resume working on after we close this new optional
+            nestedStrings.push(currentString);
+          }
+          currentString = '';
+          openOptionalSections++;
+          break;
+        case ']':
+          if (openOptionalSections === 0) {
+            // This was not preceeded by a '[', so this isn't a syntax bracket. It's a literal ']' character
+            currentString += c;
+          } else if (nestedStrings.length === 0) {
+            // We are not nested in brackets. Resume parsing with an empty literal string
+            parsedRegexString += `${parseForRegexString(currentString)}?`;
+            currentString = '';
+            openOptionalSections--;
+          } else {
+            // We are nested in brackets. Resume working on the previous literal string
+            currentString = `${nestedStrings.pop()}${parseForRegexString(currentString)}?`;
+            openOptionalSections--;
+          }
+          break;
+        case '<':
+          // if the next two characters of the string are ->, so we have '<->', treat this as a literal '>' character,
+          // not a syntax bracket
+          if (splitString.length > idx + 1 && splitString[idx+1] === '-' && splitString[idx+2] === '>') {
+            currentString += c;
+            break;
+          } else if (openOptionalSections === 0 && openMandatorySections === 0) {
+            // We are not nested in brackets, so what was written up to this point was literal text
+            parsedRegexString += currentString;
+          } else {
+            // We *are* nested in brackets
+            // Store the currentString in nested strings to resume working on after we close this new optional
+            nestedStrings.push(currentString);
+          }
+          currentString = '';
+          openMandatorySections++;
+          break;
+        case '>':
+          if (openMandatorySections === 0) {
+            // This was not preceeded by a '<', so this isn't a syntax bracket. It's a literal '>' character
+            currentString += c;
+          } else if (nestedStrings.length === 0) {
+            // We are not nested in brackets. Resume parsing with an empty literal string
+            parsedRegexString += parseForRegexString(currentString);
+            currentString = '';
+            openMandatorySections--;
+          } else {
+            // We are nested in brackets. Resume working on the previous literal string
+            currentString = `${nestedStrings.pop()}${parseForRegexString(currentString)}`;
+            openMandatorySections--;
+          }
+          break;
+        case "(":
+        case ")":
+        case "+":
+          currentString += `\\${c}`;
+          break;
+        default:
+          currentString += c;
+      }
+    });
+    parsedRegexString += currentString;
+    finalParsedRegexString += parsedRegexString;
+  });
+  return new RegExp(finalParsedRegexString);
+}

--- a/test/action-splitter.spec.ts
+++ b/test/action-splitter.spec.ts
@@ -1,0 +1,46 @@
+import test from 'ava-ts';
+
+import { splitAction } from '../src/utils/action-splitter';
+
+test('Correctly splits apart actions where the same components are moved to multiple locations', t => {
+
+  let actions = splitAction('w->3+11');
+  t.deepEqual(actions, ['w->3', 'w->11']);
+
+});
+
+test('Correctly splits apart actions where multiple components are moved to the same locations', t => {
+
+  let actions = splitAction('t1+t2+t5->');
+  t.deepEqual(actions, ['t1->', 't2->', 't5->']);
+
+  actions = splitAction('w+t_r->10');
+  t.deepEqual(actions, ['w->10', 't_r->10']);
+
+  actions = splitAction('%h+%c+%s->r');
+  t.deepEqual(actions, ['%h->r', '%c->r', '%s->r']);
+
+});
+
+test('Correctly splits apart actions where multiple components are revealed to the same target', t => {
+
+  let actions = splitAction('F#+2M#^');
+  t.deepEqual(actions, ['F#^', '2M#^']);
+
+  actions = splitAction('2F#+M#^A');
+  t.deepEqual(actions, ['2F#^A', 'M#^A']);
+
+});
+
+test('Correctly splits apart actions where multiple components in the same action are grouped', t => {
+
+  let actions = splitAction('(w+2Cw+Cb_s)3->');
+  t.deepEqual(actions, ['w3->', '2Cw3->', 'Cb_s3->']);
+
+  actions = splitAction('(2R+B)#A$->');
+  t.deepEqual(actions, ['2R#A$->', 'B#A$->']);
+
+  actions = splitAction('(2%c+%h)$V->d');
+  t.deepEqual(actions, ['2%c$V->d', '%h$V->d']);
+
+});

--- a/test/regex-former.spec.ts
+++ b/test/regex-former.spec.ts
@@ -1,0 +1,285 @@
+import test from 'ava-ts';
+
+import { formRegex } from '../src/utils/regex-former';
+
+test('Correctly forms regex for crafting cards', t => {
+
+  const craftingRegex = formRegex('Z<Craftable|||crafted>');
+  let result = 'Ztun'.match(craftingRegex);
+  t.is(result.groups.crafted, 'tun');
+  
+  result = 'Zprop'.match(craftingRegex);
+  t.is(result.groups.crafted, 'prop');
+  
+  result = 'Z@'.match(craftingRegex);
+  t.is(result.groups.crafted, '@');
+
+});
+
+test('Correctly forms regex for crafting items', t => {
+
+  const craftingRegex = formRegex('Z<Craftable|||crafted>');
+  let result = 'Z%t'.match(craftingRegex);
+  t.is(result.groups.crafted, '%t');
+  
+  result = 'Z%x'.match(craftingRegex);
+  t.is(result.groups.crafted, '%x');
+  
+  result = 'Z%s'.match(craftingRegex);
+  t.is(result.groups.crafted, '%s');
+
+});
+
+test('Does not forms regex for crafting cards with invalid names', t => {
+
+  const craftingRegex = formRegex('Z<Craftable|||crafted>');
+  let result = 'Zambush'.match(craftingRegex);
+  t.is(result, null);
+  
+  result = 'ZTun'.match(craftingRegex);
+  t.is(result, null);
+  
+  result = 'Z tun'.match(craftingRegex);
+  t.is(result, null);
+
+});
+
+test('Does not forms regex for crafting cards with invalid item types', t => {
+
+  const craftingRegex = formRegex('Z<Craftable|||crafted>');
+  let result = 'Z%q'.match(craftingRegex);
+  t.is(result, null);
+  
+  result = 'Z%%t'.match(craftingRegex);
+  t.is(result, null);
+  
+  result = 'Z%T'.match(craftingRegex);
+  t.is(result, null);
+  
+  result = 'Z%'.match(craftingRegex);
+  t.is(result, null);
+  
+  result = 'Z %t'.match(craftingRegex);
+  t.is(result, null);
+
+});
+
+test('Correctly forms regex for scoring victory points', t => {
+
+  const pointsRegex = formRegex('[Faction|||scoringFaction]++[Number|||points]');
+  let result = 'C++1'.match(pointsRegex);
+  t.is(result.groups.scoringFaction, 'C');
+  t.is(result.groups.points, '1');
+  
+  result = '++4'.match(pointsRegex);
+  t.is(result.groups.scoringFaction, undefined);
+  t.is(result.groups.points, '4');
+  
+  result = '++'.match(pointsRegex);
+  t.is(result.groups.scoringFaction, undefined);
+  t.is(result.groups.points, undefined);
+
+});
+
+test('Correctly forms regex for losing victory points', t => {
+
+  const pointsRegex = formRegex('[Faction|||scoringFaction]--[Number|||points]');
+  let result = 'C--1'.match(pointsRegex);
+  t.is(result.groups.scoringFaction, 'C');
+  t.is(result.groups.points, '1');
+  
+  result = '--4'.match(pointsRegex);
+  t.is(result.groups.scoringFaction, undefined);
+  t.is(result.groups.points, '4');
+  
+  result = '--'.match(pointsRegex);
+  t.is(result.groups.scoringFaction, undefined);
+  t.is(result.groups.points, undefined);
+
+});
+
+test('Correctly forms regex for moving a VP marker to a faction board', t => {
+
+  const movingVPMarkerRegex = formRegex('++-><FactionBoard|||targetFaction>');
+  let result = '++->C$'.match(movingVPMarkerRegex);
+  t.is(result.groups.targetFaction, 'C$');
+  
+  result = '++->$'.match(movingVPMarkerRegex);
+  t.is(result.groups.targetFaction, '$');
+
+});
+
+test('Correctly forms regex for opening a closed path', t => {
+
+  const clearMountainPathRegex = formRegex('<Clearing|||lowerClearing>_<Clearing|||upperClearing>->');
+  let result = '3_7->'.match(clearMountainPathRegex);
+  t.is(result.groups.lowerClearing, '3');
+  t.is(result.groups.upperClearing, '7');
+  
+  result = '6_11->'.match(clearMountainPathRegex);
+  t.is(result.groups.lowerClearing, '6');
+  t.is(result.groups.upperClearing, '11');
+  
+  result = '11_12->'.match(clearMountainPathRegex);
+  t.is(result.groups.lowerClearing, '11');
+  t.is(result.groups.upperClearing, '12');
+
+});
+
+test('Correctly forms regex for revealing cards', t => {
+
+  const revealRegex = formRegex('[Number|||countRevealed][Card|||cardRevealed][Faction|||revealingFaction]^[Faction|||revealedFaction]');
+  let result = '2B#C^A'.match(revealRegex);
+  t.is(result.groups.countRevealed, '2');
+  t.is(result.groups.cardRevealed, 'B#');
+  t.is(result.groups.revealingFaction, 'C');
+  t.is(result.groups.revealedFaction, 'A');
+  
+  result = '#tunC^'.match(revealRegex);
+  t.is(result.groups.countRevealed, undefined);
+  t.is(result.groups.cardRevealed, '#tun');
+  t.is(result.groups.revealingFaction, 'C');
+  t.is(result.groups.revealedFaction, undefined);
+
+  result = 'F#@^'.match(revealRegex);
+  t.is(result.groups.countRevealed, undefined);
+  t.is(result.groups.cardRevealed, 'F#@');
+  t.is(result.groups.revealingFaction, undefined);
+  t.is(result.groups.revealedFaction, undefined);
+
+  result = '^A'.match(revealRegex);
+  t.is(result.groups.countRevealed, undefined);
+  t.is(result.groups.cardRevealed, undefined);
+  t.is(result.groups.revealingFaction, undefined);
+  t.is(result.groups.revealedFaction, 'A');
+
+  result = 'F#^P'.match(revealRegex);
+  t.is(result.groups.countRevealed, undefined);
+  t.is(result.groups.cardRevealed, 'F#');
+  t.is(result.groups.revealingFaction, undefined);
+  t.is(result.groups.revealedFaction, 'P');
+
+  result = '2M#^'.match(revealRegex);
+  t.is(result.groups.countRevealed, '2');
+  t.is(result.groups.cardRevealed, 'M#');
+  t.is(result.groups.revealingFaction, undefined);
+  t.is(result.groups.revealedFaction, undefined);
+
+  result = 'V^O'.match(revealRegex);
+  t.is(result.groups.countRevealed, undefined);
+  t.is(result.groups.cardRevealed, undefined);
+  t.is(result.groups.revealingFaction, 'V');
+  t.is(result.groups.revealedFaction, 'O');
+
+});
+
+test('Correctly forms regex for moving pieces', t => {
+
+  const moveRegex = formRegex('[Number|||countMoved]<Component|||componentMoved>[Location|||origin]->[Location|||destination]');
+  let result = '2Dw3->5'.match(moveRegex);
+  t.is(result.groups.countMoved, '2');
+  t.is(result.groups.componentMoved, 'Dw');
+  t.is(result.groups.origin, '3');
+  t.is(result.groups.destination, '5');
+
+  result = '4w10->4'.match(moveRegex);
+  t.is(result.groups.countMoved, '4');
+  t.is(result.groups.componentMoved, 'w');
+  t.is(result.groups.origin, '10');
+  t.is(result.groups.destination, '4');
+  
+  result = 'b->3'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, 'b');
+  t.is(result.groups.origin, undefined);
+  t.is(result.groups.destination, '3');
+
+  result = 'p->12'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, 'p');
+  t.is(result.groups.origin, undefined);
+  t.is(result.groups.destination, '12');
+
+  result = 'At->5'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, 'At');
+  t.is(result.groups.origin, undefined);
+  t.is(result.groups.destination, '5');
+
+});
+
+test('Correctly forms regex for moving cards', t => {
+
+  const moveRegex = formRegex('[Number|||countMoved]<Component|||componentMoved>[Location|||origin]->[Location|||destination]');
+  let result = 'F#domO->C'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, 'F#dom');
+  t.is(result.groups.origin, 'O');
+  t.is(result.groups.destination, 'C');
+
+  result = '#V->P'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '#');
+  t.is(result.groups.origin, 'V');
+  t.is(result.groups.destination, 'P');
+  
+  result = 'F#C->'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, 'F#');
+  t.is(result.groups.origin, 'C');
+  t.is(result.groups.destination, undefined);
+
+  result = '#->C'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '#');
+  t.is(result.groups.origin, undefined);
+  t.is(result.groups.destination, 'C');
+
+  result = '3#A->$'.match(moveRegex);
+  t.is(result.groups.countMoved, '3');
+  t.is(result.groups.componentMoved, '#');
+  t.is(result.groups.origin, 'A');
+  t.is(result.groups.destination, '$');
+
+  result = '3F#$->'.match(moveRegex);
+  t.is(result.groups.countMoved, '3');
+  t.is(result.groups.componentMoved, 'F#');
+  t.is(result.groups.origin, '$');
+  t.is(result.groups.destination, undefined);
+
+  result = '#E->A$'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '#');
+  t.is(result.groups.origin, 'E');
+  t.is(result.groups.destination, 'A$');
+
+});
+
+test('Correctly forms regex for moving items', t => {
+
+  const moveRegex = formRegex('[Number|||countMoved]<Component|||componentMoved>[Location|||origin]->[Location|||destination]');
+  let result = '%sO$->V$'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '%s');
+  t.is(result.groups.origin, 'O$');
+  t.is(result.groups.destination, 'V$');
+
+  result = '%s12->$'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '%s');
+  t.is(result.groups.origin, '12');
+  t.is(result.groups.destination, '$');
+  
+  result = '%s->e'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '%s');
+  t.is(result.groups.origin, undefined);
+  t.is(result.groups.destination, 'e');
+
+  result = '%fe->'.match(moveRegex);
+  t.is(result.groups.countMoved, undefined);
+  t.is(result.groups.componentMoved, '%f');
+  t.is(result.groups.origin, 'e');
+  t.is(result.groups.destination, undefined);
+
+});


### PR DESCRIPTION
Action splitter turns composite actions `'(t1+t2)->5'` into an array of simple actions `['t1->5', 't2->5']`, which lets us use named regex groups for simplicity.

Regex former handles the busywork of constructing complex regexes by reading pseudoregexes, like `'Z<Craftable|||crafted>'`, and converting them into true regexes: `/Z(?<crafted>((@|dom|armor|bank|...|tun)|(%[sbcxfrth]|%_)))/`