### PR TITLE
Add location functionality for 's', 'd', 't', 'Q', and implement Purge Decree, One Evening's Rest, damaging all items

### DIFF
--- a/src/action-parser.ts
+++ b/src/action-parser.ts
@@ -1,4 +1,4 @@
-import { RootActionClearPath, RootActionCombat, RootActionCraft, RootActionDominance, RootActionGainVP, RootActionMove, RootActionReveal, RootActionTriggerPlot, RootActionUpdateFunds, RootCard, RootCardName, RootFaction, RootFactionBoard, RootItem, RootItemState, RootPiece, RootPieceType, RootLocation, RootSuit, RootThing, RootVagabondRelationshipStatus, RootForest } from './interfaces';
+import { RootActionClearPath, RootActionCombat, RootActionCraft, RootActionDominance, RootActionGainVP, RootActionMove, RootActionReveal, RootActionTriggerPlot, RootActionUpdateFunds, RootCard, RootCardName, RootFaction, RootFactionBoard, RootItem, RootItemState, RootPiece, RootPieceType, RootLocation, RootSuit, RootThing, RootVagabondRelationshipStatus, RootForest, RootVagabondItemSpecial } from './interfaces';
 import { parseConspiracyAction, parseCultAction, parseDuchyAction, parseEyrieAction, parseMarquiseAction, parseRiverfolkAction, parseVagabondAction, parseWoodlandAction } from './parsers';
 import { splitAction } from './utils/action-splitter';
 import { extendCardName } from './utils/card-name-utils';
@@ -95,11 +95,10 @@ export function parseCombat(action: string, takingFaction: RootFaction): RootAct
   return parsedAction;
 }
 
-// TODO: We need to add special locations (VagabondRelationshipStatus, VagabondItemSpecial, Quest, discard pile, maybe others) and forests
 // TODO: Add default:
 //    start: deck [card], current pawn location [pawn], supply [piece], or current faction board [item]
 //    end: discard pile [card], supply/out of game [piece], or out of game [item]
-function parseLocation(location: string, takingFaction: RootFaction): RootLocation {
+export function parseLocation(location: string, takingFaction: RootFaction): RootLocation {
   if (location == null) {
     return null;
   } else if (FACTION_BOARD_REGEX.test(location)) {
@@ -112,6 +111,10 @@ function parseLocation(location: string, takingFaction: RootFaction): RootLocati
     return location as RootFaction;
   } else if (Object.values(RootItemState).includes(location as RootItemState)) {
     return location as RootItemState;
+  } else if (Object.values(RootVagabondItemSpecial).includes(location as RootVagabondItemSpecial)) {
+    return location as RootVagabondItemSpecial;
+  } else if (location === "Q") {
+    return "Quests";
   } else if (location === "*") {
     return "Discard pile";
   } else if (FOREST_REGEX.test(location)) {
@@ -131,7 +134,7 @@ export function parseMove(action: string, takingFaction: RootFaction): RootActio
 
   for (let simpleAction of actions) {
     const result = simpleAction.match(EXTENDED_MOVE_REGEX);
-    const number = +(result.groups.countMoved || 1);
+    const number = result.groups.componentMoved === '%_' ? -1 : +(result.groups.countMoved || 1);
     const origin = parseLocation(result.groups.origin, takingFaction);
 
     const component = (function parseThing(thingString: string): RootPiece | RootCard | RootItem {

--- a/src/parsers/eyrie.ts
+++ b/src/parsers/eyrie.ts
@@ -1,5 +1,5 @@
 import { parseCard } from '../action-parser';
-import { RootAction, RootActionMove, RootFaction, RootFactionBoard } from '../interfaces';
+import { RootAction, RootActionMove, RootFaction, RootFactionBoard, RootThing } from '../interfaces';
 import { splitAction } from '../utils/action-splitter';
 import { formRegex } from '../utils/regex-former';
 
@@ -46,9 +46,16 @@ export function parseEyrieAction(action: string): RootAction {
   }
 
   if (PURGE_DECREE_REGEX.test(action)) {
+
     return {
-      things: [],         // TODO: All cards currently in Decree TO the Discard pile
+      things: [{
+        number: -1,
+        thing: null,
+        start: {faction: RootFaction.Eyrie} as RootFactionBoard,
+        destination: 'Discard pile'
+      } as RootThing]
     };
+
   }
 
   const simpleActions = splitAction(action);

--- a/src/parsers/vagabond.ts
+++ b/src/parsers/vagabond.ts
@@ -1,4 +1,5 @@
-import { RootAction, RootFaction, RootFactionBoard } from '../interfaces';
+import { parseLocation } from '../action-parser';
+import { RootAction, RootFaction, RootFactionBoard, RootThing } from '../interfaces';
 import { splitAction } from '../utils/action-splitter';
 import { formRegex } from '../utils/regex-former';
 
@@ -22,13 +23,23 @@ export function parseVagabondAction(action: string, faction: RootFaction): RootA
 
   const simpleActions = splitAction(action);
 
-  if (simpleActions.every(act => RESTORE_ITEMS_REGEX.test(act))) {  // TODO: Can also represent 'damages all items'
+  if (simpleActions.every(act => RESTORE_ITEMS_REGEX.test(act))) {
+
+    const movingComponents = [];
+    for (let simpleAction of simpleActions) {
+      const result = simpleAction.match(RESTORE_ITEMS_REGEX);
+
+      movingComponents.push({
+        number: -1,
+        thing: null,
+        start: {faction: faction} as RootFactionBoard,
+        destination: parseLocation(result.groups.restoredLocation, faction)
+      } as RootThing);
+    }
 
     return {
-      things: [],          // all damaged items move to satchel
+      things: movingComponents
     };
+
   }
-
-  return null;
-
 }

--- a/test/eyrie.action.spec.ts
+++ b/test/eyrie.action.spec.ts
@@ -91,7 +91,12 @@ test('Correctly parses an action to purge the Decree', t => {
 
   const result = parseAction('$_->', RootFaction.Eyrie) as RootActionMove;
 
-  t.deepEqual(result.things, []);  // TODO: Implement in code
+  t.deepEqual(result.things, [{
+    number: -1,
+    thing: null,
+    start: {faction: RootFaction.Eyrie} as RootFactionBoard,
+    destination: 'Discard pile'
+  }]);
 });
 
 test('Correctly parses an action to choose a Leader', t => {

--- a/test/move.basic.spec.ts
+++ b/test/move.basic.spec.ts
@@ -1,7 +1,7 @@
 import test from 'ava-ts';
 
 import { parseAction } from '../src/action-parser';
-import { RootCard, RootFaction, RootFactionBoard, RootItem, RootItemState, RootPiece, RootLocation } from '../src/interfaces/rootgame';
+import { RootCard, RootFaction, RootFactionBoard, RootItem, RootItemState, RootPiece, RootLocation, RootVagabondItemSpecial } from '../src/interfaces/rootgame';
 
 test('Move - place one of current player\'s warriors', t => {
 
@@ -201,7 +201,6 @@ test('Move - retrieve from Discard pile', t => {
 test('Move - move into a forest', t => {
 
   const result = parseAction('p->1_2_5_6_11_12', 'V' as RootFaction);
-  console.log(result.things)
 
   t.is(result.things[0].number, 1);
   t.is((result.things[0].thing as RootPiece).faction, 'V');
@@ -209,4 +208,38 @@ test('Move - move into a forest', t => {
   t.is(result.things[0].start, null);
 
   t.deepEqual(result.things[0].destination, { clearings: [1, 2, 5, 6, 11, 12] });
+});
+
+test('Move - move from the Available Quests to the faction board', t => {
+
+  const result = parseAction('M#Q->$', 'V' as RootFaction);
+
+  t.is(result.things[0].number, 1);
+  t.is((result.things[0].thing as RootCard).suit, 'M');
+  t.is(result.things[0].start, 'Quests');
+
+  t.deepEqual(result.things[0].destination, { faction: 'V' as RootFaction });
+});
+
+test('Move - move an item from the track to the satchel', t => {
+
+  const result = parseAction('%tt->s', 'V' as RootFaction);
+
+  t.is(result.things[0].number, 1);
+  t.is((result.things[0].thing as RootItem), 't');
+  t.is(result.things[0].start, RootVagabondItemSpecial.Track);
+
+  t.is(result.things[0].destination, RootVagabondItemSpecial.Satchel);
+});
+
+test("Move - correctly parses an action to damage all of the Vagabond's items", t => {
+
+  const result = parseAction('%_V$->d', 'O' as RootFaction);
+
+  t.deepEqual(result.things, [{
+    number: -1,
+    thing: null,
+    start: {faction: RootFaction.Vagabond} as RootFactionBoard,
+    destination: RootVagabondItemSpecial.Damaged
+  }]);
 });

--- a/test/vagabond.action.spec.ts
+++ b/test/vagabond.action.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava-ts';
 
-import { RootActionMove, RootFaction, RootFactionBoard } from '../src/interfaces';
+import { RootActionMove, RootFaction, RootFactionBoard, RootItemState, RootVagabondItemSpecial } from '../src/interfaces';
 import { parseAction } from '../src/action-parser';
 
 test('Correctly parses an action to choose a Character', t => {
@@ -19,5 +19,28 @@ test('Correctly parses an action to restore all items', t => {
 
   const result = parseAction('%_d->s', RootFaction.Vagabond) as RootActionMove;
 
-  t.deepEqual(result.things, []);  // TODO: Implement in code
+  t.deepEqual(result.things, [{
+    number: -1,
+    thing: null,
+    start: {faction: RootFaction.Vagabond} as RootFactionBoard,
+    destination: RootVagabondItemSpecial.Satchel
+  }]);
+});
+
+test('Correctly parses an action to restore and refresh all items', t => {
+
+  const result = parseAction('%_d->s+r', RootFaction.Vagabond) as RootActionMove;
+
+  t.deepEqual(result.things, [{
+    number: -1,
+    thing: null,
+    start: {faction: RootFaction.Vagabond} as RootFactionBoard,
+    destination: RootVagabondItemSpecial.Satchel
+  },
+  {
+    number: -1,
+    thing: null,
+    start: {faction: RootFaction.Vagabond} as RootFactionBoard,
+    destination: RootItemState.FaceUp
+  }]);
 });


### PR DESCRIPTION
Added location parsing for special item locations ('s', 'd', 't') and Available Quests.

Added functionality for moving all items from the contextual location, "%_". Arbitrarily representing this with a number of '-1' and a piece of 'null'.

Implemented actual response for purging the Eyrie decree: Arbitrarily representing this with a number of '-1' and a piece of 'null'.